### PR TITLE
fix: Don't return as completed a read if the checksum has already been consumed

### DIFF
--- a/extract_with_checksum.go
+++ b/extract_with_checksum.go
@@ -61,8 +61,8 @@ func (c *checksumCompleteCond) Complete(neko *nekoData, uncompressed []byte) boo
 	chSum := crc32.ChecksumIEEE(uncompressed)
 
 	for _, v := range c.maps {
-		if _, ok := v.checksums[chSum]; ok {
-			return true
+		if n, ok := v.checksums[chSum]; ok {
+			return n > 0
 		}
 	}
 


### PR DESCRIPTION
> _Probably not the best fix for this, but I was just doing a brand new export from scratch, and this change was the bare minimum needed to get it working again. Feel free to improve it._ 

For the file `ui.nekodata` that was part of `rw_android_0-52100.95c943f671d9dcff77d1acfd4f2d817f.patch.nekodata~1.7Gb` some file reads were being reported as `complete = true` even though all the entries for a checksum of that size had already been consumed `v.checksums[chSum] = 0` previously.

This happened mostly because **by pure luck** a subset of a file matched the checksum of another file. Most likely due to the `ui.nekodata` file being around 400Mb in size and containing around 4400 file entries.

Incorrectly reported as complete:
- Checksum: `2979717926`
- Size: `131939`

Expected details for the correct exported file:
- Checksum: `2037087572`
- Size: `1169731`
